### PR TITLE
[9.0] Following pylint rules and modifying deprecated methods

### DIFF
--- a/auth_multi/__openerp__.py
+++ b/auth_multi/__openerp__.py
@@ -20,10 +20,11 @@
 ##############################################################################
 {
     'name': 'Auth Multi Login',
-    'version': '0.1',
+    'version': '8.0.0.1.0',
     'author': 'Vauxoo',
     'category': 'Hidden',
     'website': 'http://www.vauxoo.com',
+    'license': 'AGPL-3',
     'depends': [
         'web',
         'base',
@@ -39,18 +40,7 @@
         'view/auth_view.xml',
         'wizard/merge_user_view.xml',
     ],
-    'js': [
-    ],
-    'qweb': [
-    ],
-    'css': [
-    ],
-    'demo': [
-    ],
-    'test': [
-    ],
     'installable': True,
     'auto_install': False,
     'web_preload': False,
 }
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/auth_multi/controllers/__init__.py
+++ b/auth_multi/controllers/__init__.py
@@ -1,3 +1,1 @@
 from . import main
-
-# vim:expandtab:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/auth_multi/controllers/main.py
+++ b/auth_multi/controllers/main.py
@@ -1,14 +1,14 @@
+# -*- coding: utf-8 -*-
 from openerp import http
 from openerp.http import request
 from openerp import SUPERUSER_ID
 
-openerpweb = http
-
-
 # ----------------------------------------------------------
 # Controller
 # ----------------------------------------------------------
-class auth_muti_login(openerpweb.Controller):
+
+
+class AuthMutiLogin(http.Controller):
 
     @http.route(['/do_merge/execute_merge'],
                 type='http', auth="user", website=True, multilang=True)
@@ -79,7 +79,7 @@ class auth_muti_login(openerpweb.Controller):
 
         query = {'redirect': u'do_merge/execute_merge?token=%s'
                  % post.get('token')}
-        return (type(result) == tuple) and \
+        return isinstance(result, tuple) and \
             http.local_redirect('/web/login', query=query) or \
             result and \
             http.local_redirect('/web/login', query={'redirect': '/'}) or \

--- a/auth_multi/model/user.py
+++ b/auth_multi/model/user.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -76,17 +76,15 @@ class ResUsers(models.Model):
                                   string='My Contacts',
                                   help='All my Contacts Partner')
 
-
     @api.multi
     def check_token_exist(self, values):
-        '''
-        Check if token exist with the new model that contain all token allowed
+        """Check if token exist with the new model that contain all token allowed
         by an user
         @param ids: List with user ids
         @param values: Dictionary with the values necessary to login in the
         system
         return True if the token sent in values exist else return False
-        '''
+        """
         gmail_tokens_obj = self.env['gmail.tokens']
         for user in self:
             tokens_ids = gmail_tokens_obj.\
@@ -96,20 +94,13 @@ class ResUsers(models.Model):
                         ('user_id', '=', user.id),
                         ('oauth_access_token', '=',
                          values.get('oauth_access_token'))])
-            if tokens_ids:
-                return True
-
-            else:
-                return False
-
-        return False
+            return bool(tokens_ids)
 
     @api.model
     def check_credentials(self, password):
-        '''
-        Verifies that token is allowed by the user that tries do login
+        """ Verifies that token is allowed by the user that tries do login
         @param password: String with the token sent
-        '''
+        """
         token_obj = self.env['gmail.tokens']
 
         try:
@@ -123,8 +114,7 @@ class ResUsers(models.Model):
 
     @api.model
     def _signup_create_user(self, values):
-        '''
-        Tries to create a new user but first search if any user has a email
+        """ Tries to create a new user but first search if any user has a email
         with the login that
         tries do login, if this exist verifies that has allowed the token sent
         in the method and
@@ -132,7 +122,7 @@ class ResUsers(models.Model):
         If not exist, we create a new user with the values sent
         @param values: Dictionary with the user information to search or create
         return the user id found or created
-        '''
+        """
         user_ids = self.search(['|',
                                 ('login', '=', values.get('login')),
                                 ('email', '=', values.get('login'))])
@@ -153,7 +143,6 @@ class ResUsers(models.Model):
                     })
                 values.update({'login': user_brw.login})
                 user_brw.write(values)
-                self._cr.commit()
                 return user_ids.ids[0]
 
             else:
@@ -227,9 +216,8 @@ class ResUsers(models.Model):
 
     @api.multi
     def write(self, vals):
-        '''
-        Overwrite to create a log with the changes in user groups
-        '''
+        """Overwrite to create a log with the changes in user groups
+        """
         log_obj = self.env['user.log.groups']
 
         group = False
@@ -244,26 +232,24 @@ class ResUsers(models.Model):
                 groups = groups and isinstance(groups, list) and \
                     groups[0] or groups
                 log_obj.create({
-                                   'name': record.id,
-                                   'date': time.strftime('%Y-%m-%d %H:%m:%S'),
-                                   'group_ids': [(6, 0,
-                                                  groups.get('groups_id',
-                                                             []))]
-                               })
+                    'name': record.id,
+                    'date': time.strftime('%Y-%m-%d %H:%m:%S'),
+                    'group_ids': [(6, 0,
+                                   groups.get('groups_id',
+                                              []))]})
 
         return super(ResUsers, self).write(vals)
 
     @api.multi
     def search_users_for_merge(self):
-        '''
-        Return a view with do the merge request
-        '''
-        model, action_id = self.env['ir.model.data'].\
+        """ Return a view with do the merge request
+        """
+        action_id = self.env['ir.model.data'].\
             get_object_reference('auth_multi',
                                  'search_user_merge_action')
         action = self.env['ir.actions.act_window'].\
             with_context({'default_user_id': self._uid}).\
-            browse(action_id).\
+            browse(action_id[1]).\
             read([])
         copy_dict = dict(self._context).update({'default_user_id': self._uid})
         action = action[0]

--- a/auth_multi/wizard/merge_user.py
+++ b/auth_multi/wizard/merge_user.py
@@ -69,10 +69,9 @@ class MergeUserForLogin(models.Model):
 
     @api.model
     def random_token(self):
-        '''
-        Generates an ID to identify each one of record created
+        """ Generates an ID to identify each one of record created
         return the strgin with record ID
-        '''
+        """
         # the token has an entropy of about 120 bits (6 bits/char * 20 chars)
         chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZab'\
             'cdefghijklmnopqrstuvwxyz0123456789'
@@ -84,16 +83,14 @@ class MergeUserForLogin(models.Model):
 
     @api.multi
     def change_gmail_fields(self):
-        '''
-        Originally for do login with google, we use only 3 fields that allow to
+        """ Originally for do login with google, we use only 3 fields that allow to
         login with one
         gmail account. But now we can do login with multiple gmail accounts,
         for that, this method
         change the values in old fields and sets these in the new fields used
         to do login with
         multiple gmail accounts
-
-        '''
+        """
         tokens_obj = self.env['gmail.tokens']
         user_obj = self.env['res.users']
         user_ids = user_obj.search([])
@@ -116,13 +113,12 @@ class MergeUserForLogin(models.Model):
 
     @api.model
     def send_emails(self, main_id, user_id, action, res_id):
-        '''
-        Send an email to ask permission to do merge with users that have the
+        """ Send an email to ask permission to do merge with users that have the
         same email account
         @param user_id: User id that receives the notification mail
         @param action_id: String with the token of the record created
         @param res_id: Id of record created to do merge
-        '''
+        """
         mail_mail = self.env['mail.mail']
         partner_obj = self.env['res.partner'].sudo()
         user_obj = self.env['res.users'].sudo()
@@ -182,6 +178,7 @@ class MergeUserForLogin(models.Model):
         user_ids = user_obj.search([])
         wzr_brw = self
 
+        # pylint: disable=W0612
         for user_brw in user_ids:
             users = user_obj.\
                 search([('%s' % wzr_brw.type, 'ilike',
@@ -198,11 +195,10 @@ class MergeUserForLogin(models.Model):
 
     @api.multi
     def do_pre_merge_from_users(self):
-        '''
-        Send email to ask permission to do merge or do merge directly if the
+        """ Send email to ask permission to do merge or do merge directly if the
         email of user to merge
         is the same of the main user
-        '''
+        """
         user_obj = self.env['res.users']
         wzr_brw = self.sudo()
         parent_brw = user_obj.sudo(SUPERUSER_ID).browse(wzr_brw.user_id.id)
@@ -227,7 +223,6 @@ class MergeUserForLogin(models.Model):
                 wzr_brw.write({
                     'executed': True
                 })
-                self._cr.commit()
                 body = template.\
                     render({'r':
                             {'message': _('Process Completed'),
@@ -239,7 +234,6 @@ class MergeUserForLogin(models.Model):
                     'access_token': token,
                     'user_ids': [(0, 0, {'user_id': wzr_brw.user_id.id})]
                 })
-                self._cr.commit()
                 user_mails = []
                 for i in wzr_brw.user_ids:
                     if i.user_id.id not in user_mails:
@@ -253,8 +247,7 @@ class MergeUserForLogin(models.Model):
     @api.onchange('user_id', 'type', 'search_c', 'user_ids')
     @api.multi
     def onchange_search(self):
-        '''
-        Search user with the same email sent from view and return the result or
+        """ Search user with the same email sent from view and return the result or
         a message
         @type: String with the field used to find user, this may be name or
         email
@@ -262,7 +255,7 @@ class MergeUserForLogin(models.Model):
         Criterial
         @user: User ID of the main user
         return all user found and a messagen reporting it
-        '''
+        """
         user_obj = self.env['res.users']
         parent_brw = self.user_id
         user = []
@@ -329,8 +322,7 @@ class MergeUserForLogin(models.Model):
 
     @api.multi
     def execute_merge(self):
-        """
-        Execute the merge if all users involved allow this change else show a
+        """ Execute the merge if all users involved allow this change else show a
         message reporting
         why you can't do it
         """
@@ -347,7 +339,6 @@ class MergeUserForLogin(models.Model):
                 if user.user_id.id == self._uid:
                     anony = False
                     user.write({'authorized': True})
-                    self._cr.commit()
                 elif parent_brw.id == self._uid:
                     anony = False
             if anony:
@@ -362,7 +353,6 @@ class MergeUserForLogin(models.Model):
                 merge_brw.write({
                     'executed': True
                 })
-                self._cr.commit()
                 return True
             else:
                 return False

--- a/auth_multi/wizard/merge_user.py
+++ b/auth_multi/wizard/merge_user.py
@@ -346,10 +346,13 @@ class MergeUserForLogin(models.Model):
             merge_brw = merge_ids and merge_ids[0]
             if all([i.authorized for i in merge_brw.user_ids]):
                 user_ids = [i.user_id.id for i in merge_brw.user_ids]
-                user_ids.insert(0, parent_brw.id)
-                fuse_obj.sudo().with_context({'active_model': 'res.users',
-                                              'active_ids': user_ids}).\
+                fuse_id = fuse_obj.sudo().\
+                    with_context({'active_model': 'res.users',
+                                  'active_id': parent_brw.id,
+                                  'active_ids': user_ids}).\
                     create({})
+                fuse_id.merge_records('res_users', parent_brw.id, user_ids,
+                                      'res.users')
                 merge_brw.write({
                     'executed': True
                 })

--- a/github_auth/README.rst
+++ b/github_auth/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Github Auth
+==================
+
+When you configure this, please use this configuration for the new oAuth
+provider:
+
+.. image:: /github_auth/static/src/doc/odoo_config.png
+
+And use this configuration on github:
+
+.. image:: /github_auth/static/src/doc/github_config.png
+
+Note that the client_id and key are provided by github.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/Vauxoo/odoo-users/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Contributors
+------------
+
+* Jose Morales <jose@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://www.vauxoo.com/logo.png
+    :alt: Vauxoo
+    :target: https://vauxoo.com
+
+This module is maintained by Vauxoo.
+
+a latinamerican company that provides training, coaching,
+development and implementation of enterprise management
+sytems and bases its entire operation strategy in the use
+of Open Source Software and its main product is odoo.
+
+To contribute to this module, please visit http://www.vauxoo.com.
+

--- a/github_auth/__openerp__.py
+++ b/github_auth/__openerp__.py
@@ -20,25 +20,10 @@
 ##############################################################################
 {
     'name': 'Github Auth',
-    'version': '0.1',
+    'version': '8.0.0.1.0',
+    'license': 'AGPL-3',
     'author': 'Vauxoo',
     'category': 'Hidden',
-    'description': """
-Auth wit Github API
-===================
-
-When you configure this, please use this configuration for the new oAuth
-provider:
-
-.. image:: /github_auth/static/src/doc/odoo_config.png
-
-And use this configuration on github:
-
-.. image:: /github_auth/static/src/doc/github_config.png
-
-Note that the client_id and key are provided by github.
-
-    """,
     'website': 'http://www.vauxoo.com',
     'images': [],
     'depends': [
@@ -64,4 +49,3 @@ Note that the client_id and key are provided by github.
     'auto_install': False,
     'web_preload': False,
 }
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/github_auth/model/auth_oauth.py
+++ b/github_auth/model/auth_oauth.py
@@ -1,8 +1,8 @@
+# coding: utf-8
 from openerp import models, fields
 
 
 class AuthOauthProvider(models.Model):
-    """"""
 
     _inherit = 'auth.oauth.provider'
 

--- a/merge_editing/README.rst
+++ b/merge_editing/README.rst
@@ -1,0 +1,41 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Merge Records
+==================
+
+This allows you merge records of any model 
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/Vauxoo/odoo-users/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Contributors
+------------
+
+* Oscar Alcala <oscar@vauxoo.com>
+* Jose Morales <jose@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://www.vauxoo.com/logo.png
+    :alt: Vauxoo
+    :target: https://vauxoo.com
+
+This module is maintained by Vauxoo.
+
+a latinamerican company that provides training, coaching,
+development and implementation of enterprise management
+sytems and bases its entire operation strategy in the use
+of Open Source Software and its main product is odoo.
+
+To contribute to this module, please visit http://www.vauxoo.com.
+

--- a/merge_editing/__init__.py
+++ b/merge_editing/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -21,5 +21,3 @@
 
 from . import merge_editing
 from . import wizard
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/__init__.py
+++ b/merge_editing/__init__.py
@@ -19,8 +19,7 @@
 #
 ##############################################################################
 
-import merge_editing
-import wizard
+from . import merge_editing
+from . import wizard
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
-

--- a/merge_editing/__openerp__.py
+++ b/merge_editing/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -18,16 +18,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 ##############################################################################
-
-
 {
     "name": "Merge Records",
-    "version": "1.1",
+    "version": "8.0.0.1.0",
     "author": "Vauxoo",
     "category": "Tools",
     "website": "http://www.vauxoo.com",
-    "description": """
-    """,
+    'license': 'AGPL-3',
     'depends': ['base'],
     'data': [
         'security/merge_security.xml',
@@ -38,5 +35,3 @@
     'application': True,
     'auto_install': False,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/merge_editing.py
+++ b/merge_editing/merge_editing.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -25,7 +25,7 @@ from openerp import models, fields, api, _
 from openerp import osv
 
 
-class merge_object(models.Model):
+class MergeObject(models.Model):
     _name = "merge.object"
 
     name = fields.Char("Name", size=64, required=True, select=1)
@@ -151,6 +151,3 @@ class merge_object(models.Model):
                 raise osv.except_osv(_("Warning"),
                                      _("Deletion of the action record "
                                        "failed."))
-
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/merge_editing.py
+++ b/merge_editing/merge_editing.py
@@ -64,89 +64,93 @@ class merge_object(models.Model):
             model_list = "[" + str(model_id) + ""
             active_model_obj = self.env[model_data.model]
             if active_model_obj._inherits:
-                for key, val in active_model_obj._inherits.items():
-                    model_ids = model_obj.search([('model', '=', key)])
+                for key in active_model_obj._inherits.items():
+                    model_ids = model_obj.search([('model', '=', key[0])])
                     if model_ids:
                         model_list += "," + str(model_ids._ids[0]) + ""
             model_list += "]"
         return {'value': {'model_list': model_list}}
 
-    @api.one
+    @api.multi
     def create_action_fuse(self):
         vals = {}
         action_obj = self.env['ir.actions.act_window']
         src_obj = self.model_id.model
-        button_name = _('Mass Fuse (%s)') % self.name
-        vals['ref_ir_act_window_fuse'] = action_obj.create({
-            'name': button_name,
-            'type': 'ir.actions.act_window',
-            'res_model': 'merge.fuse.wizard',
-            'src_model': src_obj,
-            'view_type': 'form',
-            'context': "{'merge_fuse_object' : %d}" % (self.id),
-            'view_mode': 'form,tree',
-            'target': 'new',
-            'auto_refresh': 1
-        })
-        vals['ref_ir_value_fuse'] = self.env['ir.values'].\
-            create({
+        for record in self:
+            button_name = _('Mass Fuse (%s)') % record.name
+            vals['ref_ir_act_window_fuse'] = action_obj.create({
                 'name': button_name,
-                'model': src_obj,
-                'key2': 'client_action_multi',
-                'value': "ir.actions.act_window," +
-                str(vals['ref_ir_act_window_fuse']),
-                'object': True,
+                'type': 'ir.actions.act_window',
+                'res_model': 'merge.fuse.wizard',
+                'src_model': src_obj,
+                'view_type': 'form',
+                'context': "{'merge_fuse_object' : %d}" % (self.id),
+                'view_mode': 'form,tree',
+                'target': 'new',
+                'auto_refresh': 1
             })
-        self.write({
-            'ref_ir_act_window_fuse': vals.
-            get('ref_ir_act_window_fuse', False),
-            'ref_ir_value_fuse': vals.get('ref_ir_value_fuse', False),
-        })
+            vals['ref_ir_value_fuse'] = self.env['ir.values'].\
+                create({
+                    'name': button_name,
+                    'model': src_obj,
+                    'key2': 'client_action_multi',
+                    'value': ("ir.actions.act_window," +
+                              str(vals['ref_ir_act_window_fuse'])),
+                    'object': True,
+                })
+            record.write({
+                'ref_ir_act_window_fuse': vals.get('ref_ir_act_window_fuse',
+                                                   False),
+                'ref_ir_value_fuse': vals.get('ref_ir_value_fuse', False),
+            })
 
-    @api.one
+    @api.multi
     def create_action(self):
         vals = {}
         action_obj = self.env['ir.actions.act_window']
         src_obj = self.model_id.model
-        button_name = _('Mass Editing (%s)') % self.name
-        vals['ref_ir_act_window'] = action_obj.create({
-            'name': button_name,
-            'type': 'ir.actions.act_window',
-            'res_model': 'merge.editing.wizard',
-            'src_model': src_obj,
-            'view_type': 'form',
-            'context': "{'merge_editing_object' : %d}" % (self.id),
-            'view_mode': 'form,tree',
-            'target': 'new',
-            'auto_refresh': 1
-        })
-        vals['ref_ir_value'] = self.env['ir.values'].create({
-            'name': button_name,
-            'model': src_obj,
-            'key2': 'client_action_multi',
-            'value': "ir.actions.act_window," + str(vals['ref_ir_act_window']),
-            'object': True,
+        for record in self:
+            button_name = _('Mass Editing (%s)') % record.name
+            vals['ref_ir_act_window'] = action_obj.create({
+                'name': button_name,
+                'type': 'ir.actions.act_window',
+                'res_model': 'merge.editing.wizard',
+                'src_model': src_obj,
+                'view_type': 'form',
+                'context': "{'merge_editing_object' : %d}" % (self.id),
+                'view_mode': 'form,tree',
+                'target': 'new',
+                'auto_refresh': 1
             })
-        self.write({
-            'ref_ir_act_window': vals.
-            get('ref_ir_act_window', False),
-            'ref_ir_value': vals.
-            get('ref_ir_value', False)
-        })
+            vals['ref_ir_value'] = self.env['ir.values'].create({
+                'name': button_name,
+                'model': src_obj,
+                'key2': 'client_action_multi',
+                'value': ("ir.actions.act_window," +
+                          str(vals['ref_ir_act_window'])),
+                'object': True,
+                })
+            record.write({
+                'ref_ir_act_window': vals.get('ref_ir_act_window',
+                                              False),
+                'ref_ir_value': vals.get('ref_ir_value', False)
+            })
 
-    @api.one
+    @api.multi
     def unlink_action(self):
-        try:
-            if self.ref_ir_act_window:
-                self.env['ir.actions.act_window'].\
-                    unlink(self.ref_ir_act_window.id)
-            if self.ref_ir_value:
-                ir_values_obj = self.env['ir.values']
-                ir_values_obj.unlink(self.ref_ir_value.id)
-        except:
-            raise osv.except_osv(_("Warning"),
-                                 _("Deletion of the action record failed."))
-        return True
+        action_env = self.env['ir.actions.act_window']
+        ir_values_obj = self.env['ir.values']
+        for record in self:
+            try:
+                if record.ref_ir_act_window:
+                    action_env.\
+                        unlink(record.ref_ir_act_window.id)
+                if self.ref_ir_value:
+                    ir_values_obj.unlink(record.ref_ir_value.id)
+            except:
+                raise osv.except_osv(_("Warning"),
+                                     _("Deletion of the action record "
+                                       "failed."))
 
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/merge_editing_view.xml
+++ b/merge_editing/merge_editing_view.xml
@@ -72,9 +72,9 @@
             <field name="act_window_id" ref="action_merge_object_form"/>
         </record>
 
-        <menuitem id="menu_merge_editing" name="Merge Editing" parent="base.menu_custom" sequence="6"/>
+        <!-- <menuitem id="menu_merge_editing" name="Merge Editing" parent="base.menu_custom" sequence="6"/> -->
 
-        <menuitem id="menu_merge_object_view" action="action_merge_object_form" parent="menu_merge_editing"/>
+        <!-- <menuitem id="menu_merge_object_view" action="action_merge_object_form" parent="menu_merge_editing"/> -->
 
     </data>
 </openerp>

--- a/merge_editing/merge_editing_view.xml
+++ b/merge_editing/merge_editing_view.xml
@@ -72,7 +72,7 @@
             <field name="act_window_id" ref="action_merge_object_form"/>
         </record>
 
-        <menuitem id="menu_merge_editing" name="merge Editing" parent="base.menu_reporting_config" sequence="6"/>
+        <menuitem id="menu_merge_editing" name="Merge Editing" parent="base.menu_custom" sequence="6"/>
 
         <menuitem id="menu_merge_object_view" action="action_merge_object_form" parent="menu_merge_editing"/>
 

--- a/merge_editing/wizard/__init__.py
+++ b/merge_editing/wizard/__init__.py
@@ -19,6 +19,6 @@
 #
 ##############################################################################
 
-import merge_editing_wizard
+from . import merge_editing_wizard
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/wizard/__init__.py
+++ b/merge_editing/wizard/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -20,5 +20,3 @@
 ##############################################################################
 
 from . import merge_editing_wizard
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/wizard/merge_editing_wizard.py
+++ b/merge_editing/wizard/merge_editing_wizard.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -89,9 +89,9 @@ class MergeFuseWizard(models.TransientModel):
             # get the models related to the one to fuse
             can = True
             for related in models_obj.browse(cr, uid, related_ids):
-                cr.commit()
                 to_unlink = []
                 target_ids = []
+                cr.commit()
                 target_model = self.pool.get(related.model)
                 field_obj = target_model and target_model.\
                     _fields.get(related.name)
@@ -137,11 +137,9 @@ class MergeFuseWizard(models.TransientModel):
                         if error.message.find('cannot update view') >= 0:
                             continue
                         can = False
-                cr.commit()
             if can:
                 to_unlink = list(set(active_ids) - set([base_id]))
                 model_obj.unlink(cr, uid, to_unlink)
-                cr.commit()
         result = super(MergeFuseWizard, self).create(cr, uid, {}, context)
         return result
 
@@ -405,7 +403,6 @@ class MergeEditingWizard(models.TransientModel):
             root = xml_form.getroottree()
             result['arch'] = etree.tostring(root)
             result['fields'] = all_fields
-            print result
         return result
 
     def create(self, cr, uid, vals, context=None):
@@ -439,6 +436,3 @@ class MergeEditingWizard(models.TransientModel):
     @api.multi
     def action_apply(self):
         return {'type': 'ir.actions.act_window_close'}
-
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/merge_editing/wizard/merge_editing_wizard.py
+++ b/merge_editing/wizard/merge_editing_wizard.py
@@ -22,6 +22,7 @@
 
 from openerp import api, models, tools
 from lxml import etree
+import re
 
 
 class MergeFuseWizard(models.TransientModel):
@@ -72,76 +73,85 @@ class MergeFuseWizard(models.TransientModel):
             result['fields'] = all_fields
         return result
 
-    def create(self, cr, uid, vals, context=None):
-        if context.get('active_model') and context.get('active_ids'):
-            active_ids = context.get('active_ids')
-            base_id = active_ids[0]
-            model_obj = self.pool.get(context.get('active_model'))
-            models_obj = self.pool.get('ir.model.fields')
-            property_obj = self.pool.get('ir.property')
-            related_ids = models_obj.search(cr, uid,
-                                            [('ttype', 'in',
-                                              ('many2one', 'one2many',
-                                               'many2many')),
-                                             ('relation', '=',
-                                              str(context.
-                                                  get('active_model')))])
-            # get the models related to the one to fuse
-            can = True
-            for related in models_obj.browse(cr, uid, related_ids):
-                to_unlink = []
-                target_ids = []
-                cr.commit()
-                target_model = self.pool.get(related.model)
-                field_obj = target_model and target_model.\
-                    _fields.get(related.name)
-                if field_obj.company_dependent:
-                    property_ids = []
-                    for field_id in active_ids:
-                        v_reference = '%s,%s' % (context.get('active_model'),
-                                                 field_id)
-                        property_ids += property_obj.\
-                            search(cr, uid,
-                                   [('fields_id', '=', related.id),
-                                    ('value_reference', '=', v_reference)],
-                                   context=context)
+    @api.multi
+    def merge_records(self, table, main_id, old_ids, orm_model):
+        '''Method used to merge records in all tables with
+        a reference to the objects to merge
+        @param tabel: Table name of the records to merge. i.e. res_users
+        @type tabel: str or unicode
+        @param main_id: Id of the main record, this id will replace the other
+                        ids in the tables related
+        @type main_id: integer
+        @param old_ids: List  with the ids of the records to merge
+        @type old_ids: list or tuple
+        @param orm_model: Name of the model for the orm. i.e. res.users
+        @type orm_model: str or unicode
+        '''
 
-                    if property_ids:
-                        v_ref = '%s,%s' % (context.get('active_model'),
-                                           base_id)
-                        property_obj.write(cr, uid, property_ids,
-                                           {'value_reference': v_ref},
-                                           context=context)
-                        continue
+        self._cr.execute('''
+DROP FUNCTION IF EXISTS merge_records(model varchar, main_id integer,
+                                      old_ids integer[], orm_model varchar);
+CREATE OR REPLACE FUNCTION merge_records(model varchar, main_id integer,
+                                         old_ids integer[], orm_model varchar)
+RETURNS float AS $$
+    DECLARE
 
-                elif field_obj.compute:
-                    if field_obj.store or field_obj.search:
-                        target_ids = target_model.search(cr, uid,
-                                                         [(related.name, 'in',
-                                                           active_ids)])
-                    else:
-                        continue
+        value_table varchar;
+        value_column varchar;
+        values RECORD;
+        proper_id integer;
+        record_id integer;
+        amount float;
+    BEGIN
+        FOR value_table, value_column IN SELECT cl1.relname as table,
+                             att1.attname as column
+                      FROM pg_constraint as con, pg_class as cl1,
+                           pg_class as cl2, pg_attribute as att1,
+                           pg_attribute as att2
+                      WHERE con.conrelid = cl1.oid
+                           AND con.confrelid = cl2.oid
+                           AND array_lower(con.conkey, 1) = 1
+                           AND con.conkey[1] = att1.attnum
+                           AND att1.attrelid = cl1.oid
+                           AND cl2.relname = model
+                           AND att2.attname = 'id'
+                           AND array_lower(con.confkey, 1) = 1
+                           AND con.confkey[1] = att2.attnum
+                           AND att2.attrelid = cl2.oid
+                           AND con.contype = 'f' LOOP
+            FOREACH record_id SLICE 0 IN ARRAY old_ids LOOP
+                proper_id := (SELECT id
+                            FROM ir_property
+                            WHERE res_id = orm_model|| ',' || record_id);
+                IF proper_id is not null THEN
+                    UPDATE ir_property SET res_id = orm_model|| ',' || main_id;
+                END IF;
+                proper_id := (SELECT id
+                            FROM ir_property
+                            WHERE value_reference = orm_model|| ',' ||
+                                    record_id);
+                IF proper_id is not null THEN
+                    UPDATE ir_property
+                    SET value_reference = orm_model|| ',' || main_id;
+                END IF;
+                BEGIN
+                    EXECUTE 'UPDATE ' || value_table ||
+                            ' SET ' || value_column || ' = ' || main_id ||
+                            ' WHERE ' || value_column || ' = '
+                                || record_id;
+                EXCEPTION WHEN unique_violation THEN
+                    -- Ignore duplicate inserts.
+                END;
+            END LOOP;
+        END LOOP;
+        RETURN amount; END;
+    $$ LANGUAGE plpgsql;''')
+        old_ids_str = re.sub(r'^(\(|\[)', '{', str(old_ids))
+        old_ids_str = re.sub(r'(\)|\])$', '}', old_ids_str)
 
-                else:
-                    target_ids = target_model and \
-                        target_model.\
-                        search(cr, uid, [(related.name, 'in', active_ids)])
-                    try:
-                        target_ids and target_model.\
-                            write(cr, uid, target_ids,
-                                  {str(related.name):
-                                   (field_obj.type in
-                                    ('many2many', 'one2many') and
-                                    [(4, base_id)] or base_id)})
-                    except BaseException as error:
-                        if error.message.find('cannot update view') >= 0:
-                            continue
-                        can = False
-            if can:
-                to_unlink = list(set(active_ids) - set([base_id]))
-                model_obj.unlink(cr, uid, to_unlink)
-        result = super(MergeFuseWizard, self).create(cr, uid, {}, context)
-        return result
+        self._cr.execute('SELECT merge_records(CAST(%s AS varchar),'
+                         '%s, %s, CAST(%s AS varchar))',
+                         (table, main_id, old_ids_str, orm_model))
 
     @api.multi
     def action_apply(self):

--- a/merge_editing/wizard/merge_editing_wizard.py
+++ b/merge_editing/wizard/merge_editing_wizard.py
@@ -75,7 +75,7 @@ class MergeFuseWizard(models.TransientModel):
 
     @api.multi
     def merge_records(self, table, main_id, old_ids, orm_model):
-        '''Method used to merge records in all tables with
+        """Method used to merge records in all tables with
         a reference to the objects to merge
         @param tabel: Table name of the records to merge. i.e. res_users
         @type tabel: str or unicode
@@ -86,7 +86,7 @@ class MergeFuseWizard(models.TransientModel):
         @type old_ids: list or tuple
         @param orm_model: Name of the model for the orm. i.e. res.users
         @type orm_model: str or unicode
-        '''
+        """
 
         self._cr.execute('''
 DROP FUNCTION IF EXISTS merge_records(model varchar, main_id integer,
@@ -121,18 +121,22 @@ RETURNS float AS $$
                            AND con.contype = 'f' LOOP
             FOREACH record_id SLICE 0 IN ARRAY old_ids LOOP
                 proper_id := (SELECT id
-                            FROM ir_property
-                            WHERE res_id = orm_model|| ',' || record_id);
+                              FROM ir_property
+                              WHERE res_id = orm_model|| ',' ||
+                                             record_id LIMIT 1);
                 IF proper_id is not null THEN
-                    UPDATE ir_property SET res_id = orm_model|| ',' || main_id;
+                    UPDATE ir_property
+                    SET res_id = orm_model|| ',' || main_id
+                    WHERE res_id = orm_model|| ',' || record_id    ;
                 END IF;
                 proper_id := (SELECT id
                             FROM ir_property
                             WHERE value_reference = orm_model|| ',' ||
-                                    record_id);
+                                    record_id LIMIT 1);
                 IF proper_id is not null THEN
                     UPDATE ir_property
-                    SET value_reference = orm_model|| ',' || main_id;
+                    SET value_reference = orm_model|| ',' || main_id
+                    WHERE value_reference = orm_model|| ',' || record_id;
                 END IF;
                 BEGIN
                     EXECUTE 'UPDATE ' || value_table ||

--- a/secret_key_auth/README.rst
+++ b/secret_key_auth/README.rst
@@ -1,0 +1,41 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Client Secret Auth
+==================
+
+This adds the client_secret field used in some
+methods of authentication by oauth
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/Vauxoo/odoo-users/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Contributors
+------------
+
+* Jose Morales <jose@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://www.vauxoo.com/logo.png
+    :alt: Vauxoo
+    :target: https://vauxoo.com
+
+This module is maintained by Vauxoo.
+
+a latinamerican company that provides training, coaching,
+development and implementation of enterprise management
+sytems and bases its entire operation strategy in the use
+of Open Source Software and its main product is odoo.
+
+To contribute to this module, please visit http://www.vauxoo.com.
+

--- a/secret_key_auth/__openerp__.py
+++ b/secret_key_auth/__openerp__.py
@@ -20,16 +20,10 @@
 ##############################################################################
 {
     'name': 'Client Secret Auth',
-    'version': '0.1',
+    'version': '8.0.0.1.0',
     'author': 'Vauxoo',
+    'license': 'AGPL-3',
     'category': 'Hidden',
-    'description': """
-Client Secret Auth
-===================
-
-This adds the client_secret field used in some
-methods of authentication by oauth
-    """,
     'website': 'http://www.vauxoo.com',
     'images': [],
     'depends': [
@@ -39,18 +33,7 @@ methods of authentication by oauth
     'data': [
         'view/auth_oauth_view.xml',
     ],
-    'js': [
-    ],
-    'qweb': [
-    ],
-    'css': [
-    ],
-    'demo': [
-    ],
-    'test': [
-    ],
     'installable': True,
     'auto_install': False,
     'web_preload': False,
 }
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/secret_key_auth/controllers/main.py
+++ b/secret_key_auth/controllers/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import functools
 import urllib2
 import logging
@@ -62,5 +63,3 @@ class OAuthControllerInherit(OAuthController):
                     response = werkzeug.url_decode(response)
                     kw.update({'access_token': response.get('access_token')})
         return super(OAuthControllerInherit, self).signin(**kw)
-
-# vim:expandtab:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/secret_key_auth/controllers/main.py
+++ b/secret_key_auth/controllers/main.py
@@ -34,7 +34,7 @@ def fragment_to_query_string(func):
     return wrapper
 
 
-class OAuthController(OAuthController):
+class OAuthControllerInherit(OAuthController):
 
     @http.route('/auth_oauth/signin', type='http', auth='none')
     @fragment_to_query_string
@@ -57,10 +57,10 @@ class OAuthController(OAuthController):
                         url = endpoint + '&' + params
                     else:
                         url = endpoint + '?' + params
-                    f = urllib2.urlopen(url)
-                    response = f.read()
+                    furl = urllib2.urlopen(url)
+                    response = furl.read()
                     response = werkzeug.url_decode(response)
                     kw.update({'access_token': response.get('access_token')})
-        return super(OAuthController, self).signin(**kw)
+        return super(OAuthControllerInherit, self).signin(**kw)
 
 # vim:expandtab:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/secret_key_auth/model/auth_oauth.py
+++ b/secret_key_auth/model/auth_oauth.py
@@ -1,12 +1,9 @@
-from openerp.osv import osv, fields
+from openerp import models, fields
 
 
-class auth_oauth_provider(osv.osv):
-    """"""
+class AuthOauthProvider(models.Model):
 
     _inherit = 'auth.oauth.provider'
 
-    _columns = {
-        'client_secret': fields.char('Client Secret',
-                                     help='The client secret you received'),
-    }
+    client_secret = fields.Char('Client Secret',
+                                help='The client secret you received')

--- a/secret_key_auth/model/auth_oauth.py
+++ b/secret_key_auth/model/auth_oauth.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from openerp import models, fields
 
 

--- a/secret_key_auth/model/res_user.py
+++ b/secret_key_auth/model/res_user.py
@@ -1,17 +1,17 @@
 import logging
-from openerp.osv import osv
+from openerp import models
 
 _logger = logging.getLogger(__name__)
 
 
-class res_users(osv.Model):
+class ResUsers(models.Model):
     _inherit = 'res.users'
 
     def _auth_oauth_rpc(self, cr, uid, endpoint, access_token, context=None):
         context = context or {}
-        response = super(res_users, self)._auth_oauth_rpc(cr, uid, endpoint,
-                                                          access_token,
-                                                          context=context)
+        response = super(ResUsers, self)._auth_oauth_rpc(cr, uid, endpoint,
+                                                         access_token,
+                                                         context=context)
         if not response.get('user_id', False):
             response.update({
                 'user_id': response.get('id'),

--- a/secret_key_auth/model/res_user.py
+++ b/secret_key_auth/model/res_user.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 from openerp import models
 


### PR DESCRIPTION
Migrated to the new api the secret_key_auth module
Applied pylint in the rest of the models and modified deprecated decorators
Moved the merge_editing menu with an according parent 
Changed the way to merge records using a new sql method, because to use the orm method we need to use commits directly inside our method
Changed the auth process to use the new method
Hidden the merge menu because it is a big power to be available and visible for anyone
